### PR TITLE
kept the earliest test within 90 days

### DIFF
--- a/emissions/data.py
+++ b/emissions/data.py
@@ -91,7 +91,7 @@ def clean_data(df, make_threshhold="0.01"):
     
     # if a vehicle has multiple test records within 1 month, keep earliest record 
     df = df.sort_values('TEST_SDATE')
-    df = df.loc[~(df.groupby('VIN')['TEST_SDATE'].diff() < np.timedelta64(1, 'M'))]
+    df = df.loc[~(df.groupby('VIN')['TEST_SDATE'].diff() < np.timedelta64(90, 'D'))]
     print(colored(f'\nRecords after keeping only the earliest test within a month for each vehicle: {df.shape[0]}', 'red'))
     
     # drop 0s in ODOMETER and remove 9999999 and 8888888
@@ -138,7 +138,8 @@ def clean_data(df, make_threshhold="0.01"):
             'BEFORE_2000',
             'ENGINE_WEIGHT_RATIO',
             'SPORT',
-            'MAKE_VEHICLE_TYPE'
+            'MAKE_VEHICLE_TYPE',
+            'TEST_SDATE'
             ]
     df = df[cols].copy()
     


### PR DESCRIPTION
changes:
1. kept the earliest test within 90 days, because their current policy with failing vehicles is that the vehicle can be retested within 90 days. We will not be predicting for retest.
2. Now the output dataframe will include TEST_SDATE. This for some exploration from my side.
@IreneSophia @hanbo-e 